### PR TITLE
Adds leads as a separate collection

### DIFF
--- a/MyCRM Leads API Sample.postman_collection.json
+++ b/MyCRM Leads API Sample.postman_collection.json
@@ -187,7 +187,7 @@
 		},
 		{
 			"key": "Scopes",
-			"value": "api"
+			"value": "api.leads"
 		},
 		{
 			"key": "AdviserContactId",


### PR DESCRIPTION
The primary postman collection contains two requests for Leads. 

This supplementary collection is a copy of them, so that they can be distributed separately.

_This new collection contains a copy of the pre-request scripts from the main collection._ Ideally we can find some method to provide this resource without duplication. 